### PR TITLE
Fix double PlayerQuitEvent fire when player disconnects

### DIFF
--- a/ProxyNetworkInterface.php
+++ b/ProxyNetworkInterface.php
@@ -208,7 +208,7 @@ final class ProxyNetworkInterface implements NetworkInterface
         }
     }
 
-    public function close(int $socketId, string $reason, bool $fromThread = false) : void
+    public function close(int $socketId, string $reason, bool $fromThread = false, bool $kicked = false) : void
     {
         static $disconnectGuard = false;
         if($disconnectGuard) {
@@ -218,8 +218,7 @@ final class ProxyNetworkInterface implements NetworkInterface
         $session = $this->getSession($socketId);
         unset($this->sessions[$socketId]);
 
-        // We don't need to call disconnect() when player is already being kicked by the server.
-        if($fromThread && $session !== null){
+        if(!$kicked && $session !== null){
             /**
              * {@link NetworkSession::tryDisconnect()} is calling the current method when calls {@link ProxyPacketSender::close()}
              */

--- a/ProxyPacketSender.php
+++ b/ProxyPacketSender.php
@@ -40,7 +40,9 @@ class ProxyPacketSender implements PacketSender
     {
         if (!$this->closed) {
             $this->closed = true;
-            $this->handler->close($this->socketId, $reason);
+
+            // We don't need to call onClientDisconnect() when player is already being kicked by the server.
+            $this->handler->close($this->socketId, $reason, false, true);
         }
     }
 }

--- a/ProxyThread.php
+++ b/ProxyThread.php
@@ -32,6 +32,7 @@ use const SO_SNDBUF;
 use const SOCK_STREAM;
 use const SOL_SOCKET;
 use const SOL_TCP;
+use const TCP_NODELAY;
 
 class ProxyThread extends Thread
 {


### PR DESCRIPTION
PlayerQuitEvent is no longer called twice when player leaves or doing $player->kick()